### PR TITLE
cloud_functions: add reloadCache query param to getMessageCounts

### DIFF
--- a/cloud_functions/src/getMessageCounts.ts
+++ b/cloud_functions/src/getMessageCounts.ts
@@ -93,6 +93,27 @@ export async function getMessageCounts(req: any, res: any) {
     res.status(204).send('');
     return;
   }
+  const { reloadCache } = req.query;
+  if (
+    reloadCache !== undefined &&
+    reloadCache !== 'true' &&
+    reloadCache !== '1' &&
+    reloadCache !== 'false' &&
+    reloadCache !== '0'
+  ) {
+    res
+      .status(400)
+      .send(
+        'incorrect value for query param: reloadCache\n. Use reloadCache=true or reloadCache=false'
+      );
+    return;
+  }
+
+  if (reloadCache === 'true' || reloadCache === '1') {
+    console.log('emptying the caches');
+    cache = { messages: {} as CountsByChain, lastUpdated: Date.now() };
+  }
+
   let messages: CountsByChain = {};
   try {
     if (


### PR DESCRIPTION
1. added reloadCache query param to getMessageCounts
2. removed pagination for missingVaa=true in getMessages. The thought being, if you have more than 100 missing vaas for a chain, you've got bigger problems than pagination and i thought having a faster refresh would be more helpful during recovery.