### PR TITLE
watcher: ignore pmu instructions in solana watcher

### DIFF
--- a/watcher/scripts/deleteMessagesByChain.ts
+++ b/watcher/scripts/deleteMessagesByChain.ts
@@ -1,0 +1,22 @@
+import * as dotenv from 'dotenv';
+dotenv.config();
+
+import { CHAIN_ID_SOLANA, coalesceChainId, coalesceChainName } from '@certusone/wormhole-sdk';
+import { padUint16 } from '@wormhole-foundation/wormhole-monitor-common';
+import { BigtableDatabase } from '../src/databases/BigtableDatabase';
+
+// Script to delete all messages for the chain given by the CHAIN variable below
+
+const CHAIN = CHAIN_ID_SOLANA;
+
+(async () => {
+  const bt = new BigtableDatabase();
+  if (!bt.bigtable) {
+    throw new Error('bigtable is undefined');
+  }
+
+  const instance = bt.bigtable.instance(bt.instanceId);
+  const messageTable = instance.table(bt.tableId);
+  await messageTable.deleteRows(`${padUint16(coalesceChainId(CHAIN).toString())}/`);
+  console.log('Deleted all rows starting with', coalesceChainName(CHAIN));
+})();

--- a/watcher/src/watchers/SolanaWatcher.ts
+++ b/watcher/src/watchers/SolanaWatcher.ts
@@ -98,10 +98,12 @@ export class SolanaWatcher extends Watcher {
       this.logger.info(`processing ${signatures.length} transactions`);
 
       // In order to determine if a transaction has a Wormhole message, we normalize and iterate
-      // through all instructions in the transaction. Only PostMessage and PostMessageUnreliable
-      // instructions are relevant when looking for messages. Then, the message account is the
-      // account given by the second index in the instruction's account key indices. From here,
-      // we can fetch the message data from the account and parse out the emitter and sequence.
+      // through all instructions in the transaction. Only PostMessage instructions are relevant
+      // when looking for messages. PostMessageUnreliable instructions are ignored because there
+      // are no data availability guarantees (ie the associated message accounts may have been
+      // reused, overwriting previous data). Then, the message account is the account given by
+      // the second index in the instruction's account key indices. From here, we can fetch the
+      // message data from the account and parse out the emitter and sequence.
       const results = await this.connection.getTransactions(
         signatures.map((s) => s.signature),
         {
@@ -140,7 +142,7 @@ export class SolanaWatcher extends Watcher {
         for (const instruction of whInstructions) {
           // skip if not postMessage instruction
           const instructionId = instruction.data;
-          if (instructionId[0] !== 0x01 && instructionId[0] !== 0x08) continue;
+          if (instructionId[0] !== 0x01) continue;
 
           const accountId = accountKeys[instruction.accountKeyIndexes[1]];
           const {


### PR DESCRIPTION
In Solana, PostMessageUnreliable may reuse the same message account to publish messages and overwrite data. Since there are no data availability guarantees for unreliable messages, the proposed solution is to ignore these instructions altogether. 

This PR also introduces a quick script to delete all rows from the messages Bigtable for a given chain that backs the `wormhole-monitor` repo to clean up the (incorrect) data stored from the last Solana backfill. 

Resolves #73 