### PR TITLE
Remove near rate limit

### DIFF
--- a/watcher/jest.config.json
+++ b/watcher/jest.config.json
@@ -3,5 +3,6 @@
     "^.+\\.tsx?$": "ts-jest"
   },
   "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
-  "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "node"]
+  "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "node"],
+  "setupFiles": ["./setup-jest.ts"]
 }

--- a/watcher/package.json
+++ b/watcher/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "start": "node dist/src/index.js",
     "dev": "ts-node src/index.ts",
-    "test": "jest --setupFiles dotenv/config --",
+    "test": "jest",
     "backfill": "ts-node scripts/backfill.ts",
     "backfill-arbitrum": "ts-node scripts/backfillArbitrum.ts",
     "backfill-near": "ts-node scripts/backfillNear.ts",

--- a/watcher/scripts/backfillNear.ts
+++ b/watcher/scripts/backfillNear.ts
@@ -5,11 +5,7 @@ import { INITIAL_DEPLOYMENT_BLOCK_BY_CHAIN } from '@wormhole-foundation/wormhole
 import { BlockResult } from 'near-api-js/lib/providers/provider';
 import ora from 'ora';
 import { initDb } from '../src/databases/utils';
-import {
-  getRateLimitedProvider,
-  getTransactionsByAccountId,
-  NEAR_ARCHIVE_RPC,
-} from '../src/utils/near';
+import { getNearProvider, getTransactionsByAccountId, NEAR_ARCHIVE_RPC } from '../src/utils/near';
 import { getMessagesFromBlockResults } from '../src/watchers/NearWatcher';
 
 // This script exists because NEAR RPC nodes do not support querying blocks older than 5 epochs
@@ -25,7 +21,7 @@ const BATCH_SIZE = 1000;
 (async () => {
   const db = initDb();
   const chain: ChainName = 'near';
-  const provider = await getRateLimitedProvider(NEAR_ARCHIVE_RPC);
+  const provider = await getNearProvider(NEAR_ARCHIVE_RPC);
   const fromBlock = Number(
     (await db.getLastBlockByChain(chain)) ?? INITIAL_DEPLOYMENT_BLOCK_BY_CHAIN[chain] ?? 0
   );

--- a/watcher/setup-jest.ts
+++ b/watcher/setup-jest.ts
@@ -1,0 +1,4 @@
+import dotenv from 'dotenv';
+dotenv.config();
+process.env.LOG_LEVEL = 'warn';
+process.env.DB_SOURCE = 'local';

--- a/watcher/src/utils/near.ts
+++ b/watcher/src/utils/near.ts
@@ -1,7 +1,6 @@
-import { sleep } from '@wormhole-foundation/wormhole-monitor-common';
 import axios from 'axios';
 import { connect } from 'near-api-js';
-import { JsonRpcProvider, Provider } from 'near-api-js/lib/providers';
+import { Provider } from 'near-api-js/lib/providers';
 import { AXIOS_CONFIG_JSON } from '../consts';
 import {
   EventLog,
@@ -14,16 +13,10 @@ import {
 const NEAR_EXPLORER_TRANSACTION_URL =
   'https://backend-mainnet-1713.onrender.com/trpc/transaction.listByAccountId';
 export const NEAR_ARCHIVE_RPC = 'https://archival-rpc.mainnet.near.org';
-export const NEAR_RATE_LIMIT_MS = 100;
 
-export const getRateLimitedProvider = async (rpc: string): Promise<Provider> => {
+export const getNearProvider = async (rpc: string): Promise<Provider> => {
   const connection = await connect({ nodeUrl: rpc, networkId: 'mainnet' });
   const provider = connection.connection.provider;
-  const originalFn = (provider as JsonRpcProvider).sendJsonRpc;
-  (provider as JsonRpcProvider).sendJsonRpc = async function <T>(method: string, params: object) {
-    await sleep(NEAR_RATE_LIMIT_MS); // respect rate limits: 600req/min
-    return originalFn.call(this, method, params) as Promise<T>;
-  };
   return provider;
 };
 

--- a/watcher/src/watchers/NearWatcher.ts
+++ b/watcher/src/watchers/NearWatcher.ts
@@ -8,7 +8,7 @@ import { RPCS_BY_CHAIN } from '../consts';
 import { VaasByBlock } from '../databases/types';
 import { makeBlockKey, makeVaaKey } from '../databases/utils';
 import { EventLog } from '../types/near';
-import { getRateLimitedProvider, isWormholePublishEventLog } from '../utils/near';
+import { getNearProvider, isWormholePublishEventLog } from '../utils/near';
 import { Watcher } from './Watcher';
 
 export class NearWatcher extends Watcher {
@@ -55,7 +55,7 @@ export class NearWatcher extends Watcher {
   }
 
   async getProvider(): Promise<Provider> {
-    return (this.provider = this.provider || (await getRateLimitedProvider(RPCS_BY_CHAIN.near!)));
+    return (this.provider = this.provider || (await getNearProvider(RPCS_BY_CHAIN.near!)));
   }
 
   isValidVaaKey(key: string) {

--- a/watcher/src/watchers/__tests__/NearWatcher.test.ts
+++ b/watcher/src/watchers/__tests__/NearWatcher.test.ts
@@ -2,12 +2,7 @@ import { CONTRACTS } from '@certusone/wormhole-sdk/lib/cjs/utils/consts';
 import { describe, expect, jest, test } from '@jest/globals';
 import { INITIAL_DEPLOYMENT_BLOCK_BY_CHAIN } from '@wormhole-foundation/wormhole-monitor-common/dist/consts';
 import { RPCS_BY_CHAIN } from '../../consts';
-import {
-  getRateLimitedProvider,
-  getTransactionsByAccountId,
-  NEAR_ARCHIVE_RPC,
-  NEAR_RATE_LIMIT_MS,
-} from '../../utils/near';
+import { getNearProvider, getTransactionsByAccountId, NEAR_ARCHIVE_RPC } from '../../utils/near';
 import { getMessagesFromBlockResults, NearWatcher } from '../NearWatcher';
 
 jest.setTimeout(60000);
@@ -27,25 +22,19 @@ test('getMessagesForBlocks', async () => {
   expect(Object.keys(messages).length).toEqual(0);
 });
 
-describe('getRateLimitedProvider', () => {
+describe('getNearProvider', () => {
   test('with normal RPC', async () => {
-    const provider = await getRateLimitedProvider(RPCS_BY_CHAIN['near']!);
-    const start = performance.now();
-
+    const provider = await getNearProvider(RPCS_BY_CHAIN['near']!);
     // grab last block from core contract
     expect(await provider.block({ finality: 'final' })).toBeTruthy();
-    expect(performance.now() - start).toBeGreaterThan(NEAR_RATE_LIMIT_MS);
   });
 
   test('with archive RPC', async () => {
-    const provider = await getRateLimitedProvider(NEAR_ARCHIVE_RPC);
-    const start = performance.now();
-
+    const provider = await getNearProvider(NEAR_ARCHIVE_RPC);
     // grab first block with activity from core contract
     expect(
       await provider.block({ blockId: 'Asie8hpJFKaipvw8jh1wPfBwwbjP6JUfsQdCuQvwr3Sz' })
     ).toBeTruthy();
-    expect(performance.now() - start).toBeGreaterThan(NEAR_RATE_LIMIT_MS);
   });
 });
 
@@ -79,7 +68,7 @@ describe('getMessagesFromBlockResults', () => {
   });
 
   test('with ArchiveProvider', async () => {
-    const provider = await getRateLimitedProvider(NEAR_ARCHIVE_RPC);
+    const provider = await getNearProvider(NEAR_ARCHIVE_RPC);
     const messages = await getMessagesFromBlockResults(provider, [
       await provider.block({ blockId: 'Bzjemj99zxe1h8kVp8H2hwVifmbQL8HT34LyPHzEK5qp' }),
       await provider.block({ blockId: '4SHFxSo8DdP8DhMauS5iFqfmdLwLET3W3e8Lg9PFvBSn' }),

--- a/watcher/src/watchers/__tests__/SolanaWatcher.test.ts
+++ b/watcher/src/watchers/__tests__/SolanaWatcher.test.ts
@@ -1,6 +1,3 @@
-import dotenv from 'dotenv';
-dotenv.config();
-
 import { expect, jest, test } from '@jest/globals';
 import { INITIAL_DEPLOYMENT_BLOCK_BY_CHAIN } from '@wormhole-foundation/wormhole-monitor-common/dist/consts';
 import { SolanaWatcher } from '../SolanaWatcher';

--- a/watcher/src/watchers/__tests__/SolanaWatcher.test.ts
+++ b/watcher/src/watchers/__tests__/SolanaWatcher.test.ts
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv';
 dotenv.config();
 
-import { describe, expect, jest, test } from '@jest/globals';
+import { expect, jest, test } from '@jest/globals';
 import { INITIAL_DEPLOYMENT_BLOCK_BY_CHAIN } from '@wormhole-foundation/wormhole-monitor-common/dist/consts';
 import { SolanaWatcher } from '../SolanaWatcher';
 
@@ -15,104 +15,104 @@ test('getFinalizedBlockNumber', async () => {
   expect(blockNumber).toBeGreaterThan(INITIAL_SOLANA_BLOCK);
 });
 
-describe('getMessagesForBlocks', () => {
-  test('single block', async () => {
-    const watcher = new SolanaWatcher();
-    const messages = await watcher.getMessagesForBlocks(170799004, 170799004);
-    expect(Object.keys(messages).length).toBe(1);
-    expect(messages).toMatchObject({
-      '170799004/2023-01-04T16:43:43.000Z': [
-        '3zWJevhFB5XqUCdDmqoRLQUMgiNBmFZLaE5rZpSexH47Mx2268eimrj2FY23Z1mq1WXsRRkyhmMcsguXcSw7Rnh1:1/ec7372995d5cc8732397fb0ad35c0121e0eaa90d26f828a534cab54391b3a4f5/262100',
-      ],
-    });
-
-    // validate keys
-    expect(watcher.isValidBlockKey(Object.keys(messages)[0])).toBe(true);
-    expect(watcher.isValidVaaKey(Object.values(messages).flat()[0])).toBe(true);
+test('getMessagesForBlocks - single block', async () => {
+  const watcher = new SolanaWatcher();
+  const messages = await watcher.getMessagesForBlocks(170799004, 170799004);
+  expect(Object.keys(messages).length).toBe(1);
+  expect(messages).toMatchObject({
+    '170799004/2023-01-04T16:43:43.000Z': [
+      '3zWJevhFB5XqUCdDmqoRLQUMgiNBmFZLaE5rZpSexH47Mx2268eimrj2FY23Z1mq1WXsRRkyhmMcsguXcSw7Rnh1:1/ec7372995d5cc8732397fb0ad35c0121e0eaa90d26f828a534cab54391b3a4f5/262100',
+    ],
   });
 
-  test('fromSlot is skipped slot', async () => {
-    const watcher = new SolanaWatcher();
-    const messages = await watcher.getMessagesForBlocks(171774030, 171774032); // 171774024 - 171774031 are skipped
-    expect(Object.keys(messages).length).toBe(1);
-    expect(messages).toMatchObject({ '171774032/2023-01-10T13:36:38.000Z': [] });
-  });
+  // validate keys
+  expect(watcher.isValidBlockKey(Object.keys(messages)[0])).toBe(true);
+  expect(watcher.isValidVaaKey(Object.values(messages).flat()[0])).toBe(true);
+});
 
-  test('toSlot is skipped slot', async () => {
-    const watcher = new SolanaWatcher();
-    const messages = await watcher.getMessagesForBlocks(171774023, 171774025);
-    expect(messages).toMatchObject({ '171774023/2023-01-10T13:36:34.000Z': [] });
-  });
+// temporary skip due to SolanaJSONRPCError: failed to get confirmed block: Block 171774030 cleaned up, does not exist on node. First available block: 176896202
+test.skip('getMessagesForBlocks - fromSlot is skipped slot', async () => {
+  const watcher = new SolanaWatcher();
+  const messages = await watcher.getMessagesForBlocks(171774030, 171774032); // 171774024 - 171774031 are skipped
+  expect(Object.keys(messages).length).toBe(1);
+  expect(messages).toMatchObject({ '171774032/2023-01-10T13:36:38.000Z': [] });
+});
 
-  test('empty block', async () => {
-    // Even if there are no messages, last block should still be returned
-    const watcher = new SolanaWatcher();
-    const messages = await watcher.getMessagesForBlocks(170979766, 170979766);
-    expect(Object.keys(messages).length).toBe(1);
-    expect(messages).toMatchObject({ '170979766/2023-01-05T18:40:24.000Z': [] });
-  });
+test('getMessagesForBlocks - toSlot is skipped slot', async () => {
+  const watcher = new SolanaWatcher();
+  const messages = await watcher.getMessagesForBlocks(171774023, 171774025);
+  expect(messages).toMatchObject({ '171774023/2023-01-10T13:36:34.000Z': [] });
+});
 
-  test('block with no transactions', async () => {
-    const watcher = new SolanaWatcher();
-    expect(watcher.getMessagesForBlocks(174108861, 174108861)).rejects.toThrowError(
-      'solana: invalid block range'
-    );
+test('getMessagesForBlocks - empty block', async () => {
+  // Even if there are no messages, last block should still be returned
+  const watcher = new SolanaWatcher();
+  const messages = await watcher.getMessagesForBlocks(170979766, 170979766);
+  expect(Object.keys(messages).length).toBe(1);
+  expect(messages).toMatchObject({ '170979766/2023-01-05T18:40:24.000Z': [] });
+});
 
-    let messages = await watcher.getMessagesForBlocks(174108661, 174108861);
-    expect(Object.keys(messages).length).toBe(1);
-    expect(Object.values(messages).flat().length).toBe(0);
+// temporary skip due to SolanaJSONRPCError: failed to get confirmed block: Block 174108865 cleaned up, does not exist on node. First available block: 176892532
+test.skip('getMessagesForBlocks - block with no transactions', async () => {
+  const watcher = new SolanaWatcher();
+  expect(watcher.getMessagesForBlocks(174108861, 174108861)).rejects.toThrowError(
+    'solana: invalid block range'
+  );
 
-    messages = await watcher.getMessagesForBlocks(174108863, 174109061);
-    expect(Object.keys(messages).length).toBe(1);
-    expect(Object.values(messages).flat().length).toBe(0);
-  });
+  let messages = await watcher.getMessagesForBlocks(174108661, 174108861);
+  expect(Object.keys(messages).length).toBe(1);
+  expect(Object.values(messages).flat().length).toBe(0);
 
-  test('multiple blocks', async () => {
-    const watcher = new SolanaWatcher();
-    const messages = await watcher.getMessagesForBlocks(171050470, 171050474);
-    expect(Object.keys(messages).length).toBe(2);
-    expect(Object.values(messages).flat().length).toBe(2);
-  });
+  messages = await watcher.getMessagesForBlocks(174108863, 174109061);
+  expect(Object.keys(messages).length).toBe(1);
+  expect(Object.values(messages).flat().length).toBe(0);
+});
 
-  test('multiple blocks, last block empty', async () => {
-    const watcher = new SolanaWatcher();
-    const messages = await watcher.getMessagesForBlocks(170823000, 170825000);
-    expect(Object.keys(messages).length).toBe(3);
-    expect(Object.values(messages).flat().length).toBe(2); // 2 messages, last block has no message
-  });
+test('getMessagesForBlocks - multiple blocks', async () => {
+  const watcher = new SolanaWatcher();
+  const messages = await watcher.getMessagesForBlocks(171050470, 171050474);
+  expect(Object.keys(messages).length).toBe(2);
+  expect(Object.values(messages).flat().length).toBe(2);
+});
 
-  test('multiple blocks containing more than `getSignaturesLimit` WH transactions', async () => {
-    const watcher = new SolanaWatcher();
-    watcher.getSignaturesLimit = 10;
-    const messages = await watcher.getMessagesForBlocks(171582367, 171583452);
-    expect(Object.keys(messages).length).toBe(3);
-    expect(Object.values(messages).flat().length).toBe(3);
-  });
+test('getMessagesForBlocks - multiple blocks, last block empty', async () => {
+  const watcher = new SolanaWatcher();
+  const messages = await watcher.getMessagesForBlocks(170823000, 170825000);
+  expect(Object.keys(messages).length).toBe(3);
+  expect(Object.values(messages).flat().length).toBe(2); // 2 messages, last block has no message
+});
 
-  test('multiple calls', async () => {
-    const watcher = new SolanaWatcher();
-    const messages1 = await watcher.getMessagesForBlocks(171773021, 171773211);
-    const messages2 = await watcher.getMessagesForBlocks(171773212, 171773250);
-    const messages3 = await watcher.getMessagesForBlocks(171773251, 171773500);
-    const allMessageKeys = [
-      ...Object.keys(messages1),
-      ...Object.keys(messages2),
-      ...Object.keys(messages3),
-    ];
-    const uniqueMessageKeys = [...new Set(allMessageKeys)];
-    expect(allMessageKeys.length).toBe(uniqueMessageKeys.length); // assert no duplicate keys
-  });
+test('getMessagesForBlocks - multiple blocks containing more than `getSignaturesLimit` WH transactions', async () => {
+  const watcher = new SolanaWatcher();
+  watcher.getSignaturesLimit = 10;
+  const messages = await watcher.getMessagesForBlocks(171582367, 171583452);
+  expect(Object.keys(messages).length).toBe(3);
+  expect(Object.values(messages).flat().length).toBe(3);
+});
 
-  test('handle failed transactions', async () => {
-    const watcher = new SolanaWatcher();
-    const messages = await watcher.getMessagesForBlocks(94401321, 94501321);
-    expect(Object.keys(messages).length).toBe(6);
-    expect(Object.values(messages).flat().length).toBe(5);
-    expect(
-      Object.values(messages)
-        .flat()
-        .map((m) => m.split('/')[2])
-        .join(',')
-    ).toBe('4,3,2,1,0');
-  });
+test('getMessagesForBlocks - multiple calls', async () => {
+  const watcher = new SolanaWatcher();
+  const messages1 = await watcher.getMessagesForBlocks(171773021, 171773211);
+  const messages2 = await watcher.getMessagesForBlocks(171773212, 171773250);
+  const messages3 = await watcher.getMessagesForBlocks(171773251, 171773500);
+  const allMessageKeys = [
+    ...Object.keys(messages1),
+    ...Object.keys(messages2),
+    ...Object.keys(messages3),
+  ];
+  const uniqueMessageKeys = [...new Set(allMessageKeys)];
+  expect(allMessageKeys.length).toBe(uniqueMessageKeys.length); // assert no duplicate keys
+});
+
+test('getMessagesForBlocks - handle failed transactions', async () => {
+  const watcher = new SolanaWatcher();
+  const messages = await watcher.getMessagesForBlocks(94401321, 94501321);
+  expect(Object.keys(messages).length).toBe(6);
+  expect(Object.values(messages).flat().length).toBe(5);
+  expect(
+    Object.values(messages)
+      .flat()
+      .map((m) => m.split('/')[2])
+      .join(',')
+  ).toBe('4,3,2,1,0');
 });


### PR DESCRIPTION
The near monitor has been running with the rate limit and I confirmed that the backfill runs fine without it as well. Also a couple CI tests have been flaking for Solana due to issues with the backing RPC nodes, so I figured we can skip them for now. Also also, I was annoyed by the info level logging in the tests 🙂 