### PR TITLE
common: correct algo initial block to first pub

### DIFF
--- a/common/src/consts.ts
+++ b/common/src/consts.ts
@@ -9,7 +9,7 @@ export const INITIAL_DEPLOYMENT_BLOCK_BY_CHAIN: {
   polygon: '20629146',
   avalanche: '8237163',
   oasis: '1757',
-  algorand: '23753839',
+  algorand: '22931277',
   fantom: '31817467',
   karura: '1824665',
   acala: '1144161',


### PR DESCRIPTION
This is the tx with sequence number 1 (what Algorand starts with) https://algoexplorer.io/tx/2RBQLCETCLFV4F3PQ7IHEWVWQV3MCP4UM5S5OFZM23XMC2O2DJ6A/inner-tx/1 which occurred on block `22931277`. Correcting this fixes an issue when starting fresh on Algorand where it would only pick up starting at the second message published, leaving a gap.