### PR TITLE
watcher: add Terra explorer

### DIFF
--- a/watcher/src/watchers/TerraExplorerWatcher.ts
+++ b/watcher/src/watchers/TerraExplorerWatcher.ts
@@ -1,0 +1,233 @@
+import { CONTRACTS, CosmWasmChainName } from '@certusone/wormhole-sdk/lib/cjs/utils/consts';
+import axios from 'axios';
+import { RPCS_BY_CHAIN } from '../consts';
+import { VaasByBlock } from '../databases/types';
+import { makeBlockKey, makeVaaKey } from '../databases/utils';
+import { Watcher } from './Watcher';
+
+export class TerraExplorerWatcher extends Watcher {
+  // Arbitrarily large since the code here is capable of pulling all logs from all via indexer pagination
+  maximumBatchSize: number = 100000;
+
+  latestBlockTag: string;
+  getBlockTag: string;
+  allTxsTag: string;
+  rpc: string | undefined;
+  latestBlockHeight: number;
+
+  constructor(chain: CosmWasmChainName) {
+    super(chain);
+    this.rpc = RPCS_BY_CHAIN[this.chain];
+    if (!this.rpc) {
+      throw new Error(`${this.chain} RPC is not defined!`);
+    }
+    this.latestBlockTag = 'blocks/latest';
+    this.getBlockTag = 'blocks/';
+    this.allTxsTag = 'v1/txs?';
+    this.latestBlockHeight = 0;
+  }
+
+  async getFinalizedBlockNumber(): Promise<number> {
+    const result = (await axios.get(`${this.rpc}/${this.latestBlockTag}`)).data;
+    if (result && result.block.header.height) {
+      let blockHeight: number = parseInt(result.block.header.height);
+      if (blockHeight !== this.latestBlockHeight) {
+        this.latestBlockHeight = blockHeight;
+        this.logger.debug('blockHeight = ' + blockHeight);
+      }
+      return blockHeight;
+    }
+    throw new Error(`Unable to parse result of ${this.latestBlockTag} on ${this.rpc}`);
+  }
+
+  // retrieve blocks for core contract.
+  // use "next": as the pagination key
+  // compare block height ("height":) with what is passed in.
+  async getMessagesForBlocks(fromBlock: number, toBlock: number): Promise<VaasByBlock> {
+    const address = CONTRACTS.MAINNET[this.chain].core;
+    if (!address) {
+      throw new Error(`Core contract not defined for ${this.chain}`);
+    }
+    this.logger.debug(`core contract for ${this.chain} is ${address}`);
+    let vaasByBlock: VaasByBlock = {};
+    this.logger.info(`fetching info for blocks ${fromBlock} to ${toBlock}`);
+
+    const limit: number = 100;
+    let done: boolean = false;
+    let offset: number = 0;
+    let lastBlockInserted: number = 0;
+    while (!done) {
+      // This URL gets the paginated list of transactions for the core contract
+      let url: string = `${this.rpc}/${this.allTxsTag}offset=${offset}&limit=${limit}&account=${address}`;
+      this.logger.debug(`Query string = ${url}`);
+      const bulkTxnResult: BulkTxnResult = (
+        await axios.get(url, {
+          headers: {
+            'User-Agent': 'Mozilla/5.0',
+          },
+        })
+      ).data;
+      if (!bulkTxnResult) {
+        throw new Error('bad bulkTxnResult');
+      }
+      offset = bulkTxnResult.next;
+      const bulkTxns: BulkTxn[] = bulkTxnResult.txs;
+      if (!bulkTxns) {
+        throw new Error('No transactions');
+      }
+      for (let i: number = 0; i < bulkTxns.length; ++i) {
+        // Walk the transactions
+        const txn: BulkTxn = bulkTxns[i];
+        const height: number = parseInt(txn.height);
+        if (height >= fromBlock && height <= toBlock) {
+          // We only care about the transactions in the given block range
+          this.logger.debug(`Found one: ${fromBlock}, ${height}, ${toBlock}`);
+          const blockKey = makeBlockKey(txn.height, new Date(txn.timestamp).toISOString());
+          vaasByBlock[blockKey] = [];
+          lastBlockInserted = height;
+          this.logger.debug(`lastBlockInserted = ${lastBlockInserted}`);
+          let vaaKey: string = '';
+          // Each txn has an array of raw_logs
+          const rawLogs: RawLogEvents[] = JSON.parse(txn.raw_log);
+          for (let j: number = 0; j < rawLogs.length; ++j) {
+            const rawLog: RawLogEvents = rawLogs[j];
+            const events: EventObjectsTypes[] = rawLog.events;
+            if (!events) {
+              this.logger.debug(
+                `No events in rawLog${j} for block ${height}, hash = ${txn.txhash}`
+              );
+              continue;
+            }
+            for (let k: number = 0; k < events.length; k++) {
+              const event: EventObjectsTypes = events[k];
+              if (event.type === 'wasm') {
+                if (event.attributes) {
+                  let attrs = event.attributes;
+                  let emitter: string = '';
+                  let sequence: string = '';
+                  let coreContract: boolean = false;
+                  // only care about _contract_address, message.sender and message.sequence
+                  const numAttrs = attrs.length;
+                  for (let l = 0; l < numAttrs; l++) {
+                    const key = attrs[l].key;
+                    if (key === 'message.sender') {
+                      emitter = attrs[l].value;
+                    } else if (key === 'message.sequence') {
+                      sequence = attrs[l].value;
+                    } else if (key === '_contract_address' || key === 'contract_address') {
+                      let addr = attrs[l].value;
+                      if (addr === address) {
+                        coreContract = true;
+                      }
+                    }
+                  }
+                  if (coreContract && emitter !== '' && sequence !== '') {
+                    vaaKey = makeVaaKey(txn.txhash, this.chain, emitter, sequence);
+                    this.logger.debug('blockKey: ' + blockKey);
+                    this.logger.debug('Making vaaKey: ' + vaaKey);
+                    vaasByBlock[blockKey] = [...(vaasByBlock[blockKey] || []), vaaKey];
+                  }
+                }
+              }
+            }
+          }
+        }
+        if (height < fromBlock) {
+          this.logger.debug('Breaking out due to height < fromBlock');
+          done = true;
+          break;
+        }
+      }
+      if (bulkTxns.length < limit) {
+        this.logger.debug('Breaking out due to ran out of txns.');
+        done = true;
+      }
+    }
+    if (lastBlockInserted < toBlock) {
+      // Need to create something for the last requested block because it will
+      // become the new starting point for subsequent calls.
+      this.logger.debug(`Adding filler for block ${toBlock}`);
+      const blkUrl = `${this.rpc}/${this.getBlockTag}${toBlock}`;
+      const result: CosmwasmBlockResult = (await axios.get(blkUrl)).data;
+      if (!result) {
+        throw new Error(`Unable to get block information for block ${toBlock}`);
+      }
+      const blockKey = makeBlockKey(
+        result.block.header.height.toString(),
+        new Date(result.block.header.time).toISOString()
+      );
+      vaasByBlock[blockKey] = [];
+    }
+    return vaasByBlock;
+  }
+}
+
+type BulkTxnResult = {
+  next: number; //400123609;
+  limit: number; //10;
+  txs: BulkTxn[];
+};
+
+type BulkTxn = {
+  id: number; //400300689;
+  chainId: string; //'columbus-5';
+  tx: [Object];
+  logs: [];
+  height: string; //'11861053';
+  txhash: string; //'31C82DC3432B4824B5195AA572A8963BA6147CAFD3ADAC6C5250BF447FA5D206';
+  raw_log: string;
+  gas_used: string; //'510455';
+  timestamp: string; //'2023-03-10T12:18:05Z';
+  gas_wanted: string; //'869573';
+};
+
+type RawLogEvents = {
+  msg_index?: number;
+  events: EventObjectsTypes[];
+};
+
+type EventObjectsTypes = {
+  type: string;
+  attributes: Attribute[];
+};
+
+type Attribute = {
+  key: string;
+  value: string;
+};
+
+type CosmwasmBlockResult = {
+  block_id: {
+    hash: string;
+    parts: {
+      total: number;
+      hash: string;
+    };
+  };
+  block: {
+    header: {
+      version: { block: string };
+      chain_id: string;
+      height: string;
+      time: string; // eg. '2023-01-03T12:13:00.849094631Z'
+      last_block_id: { hash: string; parts: { total: number; hash: string } };
+      last_commit_hash: string;
+      data_hash: string;
+      validators_hash: string;
+      next_validators_hash: string;
+      consensus_hash: string;
+      app_hash: string;
+      last_results_hash: string;
+      evidence_hash: string;
+      proposer_address: string;
+    };
+    data: { txs: string[] | null };
+    evidence: { evidence: null };
+    last_commit: {
+      height: string;
+      round: number;
+      block_id: { hash: string; parts: { total: number; hash: string } };
+      signatures: string[];
+    };
+  };
+};

--- a/watcher/src/watchers/__tests__/CosmwasmWatcher.test.ts
+++ b/watcher/src/watchers/__tests__/CosmwasmWatcher.test.ts
@@ -1,5 +1,6 @@
 import { expect, jest, test } from '@jest/globals';
 import { CosmwasmWatcher } from '../CosmwasmWatcher';
+import { TerraExplorerWatcher } from '../TerraExplorerWatcher';
 
 jest.setTimeout(60000);
 
@@ -43,6 +44,37 @@ test('getMessagesForBlocks(terra)', async () => {
   expect(vaasByBlock['10974196/2023-01-06T04:23:21.045Z'][0]).toEqual(
     '8A31CDE56ED3ACB7239D705949BD6C164747210A6C4C69D98756E0CF6D22C9EB:3/0000000000000000000000007cf7b764e38a0a5e967972c1df77d432510564e2/256813'
   );
+});
+
+test('getFinalizedBlockNumber(terra explorer)', async () => {
+  const watcher = new TerraExplorerWatcher('terra');
+  const blockNumber = await watcher.getFinalizedBlockNumber();
+  expect(blockNumber).toBeGreaterThan(10980872);
+});
+
+test('getMessagesForBlocks(terra explorer)', async () => {
+  const watcher = new TerraExplorerWatcher('terra');
+  const vaasByBlock = await watcher.getMessagesForBlocks(10974196, 10974197);
+  const entries = Object.entries(vaasByBlock);
+  expect(entries.length).toEqual(2);
+  expect(entries.filter(([block, vaas]) => vaas.length === 0).length).toEqual(1);
+  expect(entries.filter(([block, vaas]) => vaas.length === 1).length).toEqual(1);
+  expect(entries.filter(([block, vaas]) => vaas.length === 2).length).toEqual(0);
+  expect(vaasByBlock['10974196/2023-01-06T04:23:21.000Z']).toBeDefined();
+  expect(vaasByBlock['10974196/2023-01-06T04:23:21.000Z'].length).toEqual(1);
+  expect(vaasByBlock['10974196/2023-01-06T04:23:21.000Z'][0]).toEqual(
+    '8A31CDE56ED3ACB7239D705949BD6C164747210A6C4C69D98756E0CF6D22C9EB:3/0000000000000000000000007cf7b764e38a0a5e967972c1df77d432510564e2/256813'
+  );
+});
+
+test('getMessagesForBlocks(terra explorer, no useful info)', async () => {
+  const watcher = new TerraExplorerWatcher('terra');
+  const vaasByBlock = await watcher.getMessagesForBlocks(10975000, 10975010);
+  const entries = Object.entries(vaasByBlock);
+  expect(entries.length).toEqual(1);
+  expect(entries.filter(([block, vaas]) => vaas.length === 0).length).toEqual(1);
+  expect(entries.filter(([block, vaas]) => vaas.length === 1).length).toEqual(0);
+  expect(entries.filter(([block, vaas]) => vaas.length === 2).length).toEqual(0);
 });
 
 test('getFinalizedBlockNumber(xpla)', async () => {

--- a/watcher/src/watchers/__tests__/SolanaWatcher.test.ts
+++ b/watcher/src/watchers/__tests__/SolanaWatcher.test.ts
@@ -28,20 +28,20 @@ test('getMessagesForBlocks - single block', async () => {
 });
 
 // temporary skip due to SolanaJSONRPCError: failed to get confirmed block: Block 171774030 cleaned up, does not exist on node. First available block: 176896202
-test.skip('getMessagesForBlocks - fromSlot is skipped slot', async () => {
+test('getMessagesForBlocks - fromSlot is skipped slot', async () => {
   const watcher = new SolanaWatcher();
   const messages = await watcher.getMessagesForBlocks(171774030, 171774032); // 171774024 - 171774031 are skipped
   expect(Object.keys(messages).length).toBe(1);
   expect(messages).toMatchObject({ '171774032/2023-01-10T13:36:38.000Z': [] });
 });
 
-test.skip('getMessagesForBlocks - toSlot is skipped slot', async () => {
+test('getMessagesForBlocks - toSlot is skipped slot', async () => {
   const watcher = new SolanaWatcher();
   const messages = await watcher.getMessagesForBlocks(171774023, 171774025);
   expect(messages).toMatchObject({ '171774023/2023-01-10T13:36:34.000Z': [] });
 });
 
-test.skip('getMessagesForBlocks - empty block', async () => {
+test('getMessagesForBlocks - empty block', async () => {
   // Even if there are no messages, last block should still be returned
   const watcher = new SolanaWatcher();
   const messages = await watcher.getMessagesForBlocks(170979766, 170979766);
@@ -50,7 +50,7 @@ test.skip('getMessagesForBlocks - empty block', async () => {
 });
 
 // temporary skip due to SolanaJSONRPCError: failed to get confirmed block: Block 174108865 cleaned up, does not exist on node. First available block: 176892532
-test.skip('getMessagesForBlocks - block with no transactions', async () => {
+test('getMessagesForBlocks - block with no transactions', async () => {
   const watcher = new SolanaWatcher();
   expect(watcher.getMessagesForBlocks(174108861, 174108861)).rejects.toThrowError(
     'solana: invalid block range'
@@ -65,21 +65,21 @@ test.skip('getMessagesForBlocks - block with no transactions', async () => {
   expect(Object.values(messages).flat().length).toBe(0);
 });
 
-test.skip('getMessagesForBlocks - multiple blocks', async () => {
+test('getMessagesForBlocks - multiple blocks', async () => {
   const watcher = new SolanaWatcher();
   const messages = await watcher.getMessagesForBlocks(171050470, 171050474);
   expect(Object.keys(messages).length).toBe(2);
   expect(Object.values(messages).flat().length).toBe(2);
 });
 
-test.skip('getMessagesForBlocks - multiple blocks, last block empty', async () => {
+test('getMessagesForBlocks - multiple blocks, last block empty', async () => {
   const watcher = new SolanaWatcher();
   const messages = await watcher.getMessagesForBlocks(170823000, 170825000);
   expect(Object.keys(messages).length).toBe(3);
   expect(Object.values(messages).flat().length).toBe(2); // 2 messages, last block has no message
 });
 
-test.skip('getMessagesForBlocks - multiple blocks containing more than `getSignaturesLimit` WH transactions', async () => {
+test('getMessagesForBlocks - multiple blocks containing more than `getSignaturesLimit` WH transactions', async () => {
   const watcher = new SolanaWatcher();
   watcher.getSignaturesLimit = 10;
   const messages = await watcher.getMessagesForBlocks(171582367, 171583452);
@@ -87,7 +87,7 @@ test.skip('getMessagesForBlocks - multiple blocks containing more than `getSigna
   expect(Object.values(messages).flat().length).toBe(3);
 });
 
-test.skip('getMessagesForBlocks - multiple calls', async () => {
+test('getMessagesForBlocks - multiple calls', async () => {
   const watcher = new SolanaWatcher();
   const messages1 = await watcher.getMessagesForBlocks(171773021, 171773211);
   const messages2 = await watcher.getMessagesForBlocks(171773212, 171773250);
@@ -101,7 +101,7 @@ test.skip('getMessagesForBlocks - multiple calls', async () => {
   expect(allMessageKeys.length).toBe(uniqueMessageKeys.length); // assert no duplicate keys
 });
 
-test.skip('getMessagesForBlocks - handle failed transactions', async () => {
+test('getMessagesForBlocks - handle failed transactions', async () => {
   const watcher = new SolanaWatcher();
   const messages = await watcher.getMessagesForBlocks(94401321, 94501321);
   expect(Object.keys(messages).length).toBe(6);

--- a/watcher/src/watchers/utils.ts
+++ b/watcher/src/watchers/utils.ts
@@ -10,6 +10,7 @@ import { NearWatcher } from './NearWatcher';
 import { OptimismWatcher } from './OptimismWatcher';
 import { PolygonWatcher } from './PolygonWatcher';
 import { SolanaWatcher } from './SolanaWatcher';
+import { TerraExplorerWatcher } from './TerraExplorerWatcher';
 import { Watcher } from './Watcher';
 
 export function makeFinalizedWatcher(chainName: ChainName): Watcher {
@@ -41,13 +42,10 @@ export function makeFinalizedWatcher(chainName: ChainName): Watcher {
     return new AptosWatcher();
   } else if (chainName === 'near') {
     return new NearWatcher();
-  } else if (
-    chainName === 'terra' ||
-    chainName === 'terra2' ||
-    chainName === 'xpla' ||
-    chainName === 'injective'
-  ) {
+  } else if (chainName === 'terra2' || chainName === 'xpla' || chainName === 'injective') {
     return new CosmwasmWatcher(chainName);
+  } else if (chainName === 'terra') {
+    return new TerraExplorerWatcher('terra');
   } else {
     throw new Error(`Attempted to create finalized watcher for unsupported chain ${chainName}`);
   }


### PR DESCRIPTION
This PR adds the "explorer" version of the watcher for terra classic.
Should the following files, also, be updated as part of this PR:
```
watcher/src/watchers/utils.ts
watcher/src/watchers/index.ts